### PR TITLE
Add USB hub connection troubleshooting

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = Interbotix X-Series Manipulators Documentation
+SPHINXPROJ    = ALOHA Documentation
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -15,3 +15,17 @@ SLATE Base
 See the guides on `the SLATE Base documentation site`_.
 
 .. _`the SLATE Base documentation site`: https://docs.trossenrobotics.com/slate_docs/troubleshooting.html
+
+Device Connection Issues
+========================
+
+USB Hubs
+--------
+
+If using an ALOHA version with the Sabrent 7-Port USB Hubs and fail to see all connected devices when running bringup, check the following steps:
+
+*   Check that all cables are fully inserted into their ports on both ends.
+*   Check that all buttons corresponding to occupied ports are pressed.
+    The LEDs should be lit and the button should be depressed.
+*   We have found that, occasionally, switching the port that a cable is plugged into can resolve connection issues.
+    Make sure that the button of the now empty port is pressed so that it is off, and that the button of the now occupied port has been depressed.

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -28,4 +28,4 @@ If using an ALOHA version with the Sabrent 7-Port USB Hubs and fail to see all c
 *   Check that all buttons corresponding to occupied ports are pressed.
     The LEDs should be lit and the button should be depressed.
 *   We have found that, occasionally, switching the port that a cable is plugged into can resolve connection issues.
-    Make sure that the button of the now empty port is pressed so that it is off, and that the button of the now occupied port has been depressed.
+    Make sure that the button of the now empty port is pressed again so that it is released, and that the button of the now occupied port has been depressed.


### PR DESCRIPTION
This PR does the following:

* Adds a troubleshooting guide for USB hub when devices are not found during bringup.
* Fix SPHINXPROJ name in Makefile