### PR TITLE
Bump upload-pages-artifact to v3

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/configure-pages@v3
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: 'docs/_build/html'
 


### PR DESCRIPTION
This PR bumps the version of the upload-pages-artifact action from v2 to v3.