### PR TITLE
Fix aloha_static->aloha_stationary

### DIFF
--- a/docs/files/LeRobot_Notebook.ipynb
+++ b/docs/files/LeRobot_Notebook.ipynb
@@ -66,7 +66,7 @@
         "print(\"You can explore datasets from Trossen Robotics Community here: https://huggingface.co/TrossenRoboticsCommunity\")\n",
         "\n",
         "# Dataset and job details\n",
-        "dataset_repo_id = input(\"Please enter the dataset repo ID from Hugging Face (e.g., TrossenRoboticsCommunity/aloha_static_logo_assembly): \")\n",
+        "dataset_repo_id = input(\"Please enter the dataset repo ID from Hugging Face (e.g., TrossenRoboticsCommunity/aloha_stationary_logo_assembly): \")\n",
         "\n",
         "\n",
         "print(\"**Important**: Use a valid directory/jobs name. Avoid numbers or special characters other than '_'.\")\n",
@@ -86,7 +86,7 @@
         "upload_choice = input(\"Do you want to upload the model to Hugging Face after training? (yes/no): \")\n",
         "model_repo_id = \"\"\n",
         "if upload_choice.lower() == 'yes':\n",
-        "    model_repo_id = input(\"Please enter the model repo ID to store your trained model to Hugging Face (e.g., TrossenRoboticsCommunity/aloha_static_logo_assembly): \")\n",
+        "    model_repo_id = input(\"Please enter the model repo ID to store your trained model to Hugging Face (e.g., TrossenRoboticsCommunity/aloha_stationary_logo_assembly): \")\n",
         "\n",
         "# Local storage flag\n",
         "store_locally = input(\"Do you want to store the training outputs locally? (yes/no): \")\n",
@@ -190,6 +190,10 @@
     },
     {
       "cell_type": "markdown",
+      "id": "BONV4GelxZla",
+      "metadata": {
+        "id": "BONV4GelxZla"
+      },
       "source": [
         "> **⚠️ Important Notice:**\n",
         ">\n",
@@ -204,11 +208,7 @@
         "> - **Learning Rate** (`training.lr`): Set the learning rate to control how quickly the model learns.\n",
         ">\n",
         "> Once the file is updated, you can proceed with training.\n"
-      ],
-      "metadata": {
-        "id": "BONV4GelxZla"
-      },
-      "id": "BONV4GelxZla"
+      ]
     },
     {
       "cell_type": "markdown",
@@ -353,20 +353,20 @@
     }
   ],
   "metadata": {
-    "language_info": {
-      "name": "python"
-    },
+    "accelerator": "GPU",
     "colab": {
-      "provenance": [],
-      "machine_shape": "hm",
       "gpuType": "A100",
-      "private_outputs": true
+      "machine_shape": "hm",
+      "private_outputs": true,
+      "provenance": []
     },
     "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
+      "display_name": "Python 3",
+      "name": "python3"
     },
-    "accelerator": "GPU"
+    "language_info": {
+      "name": "python"
+    }
   },
   "nbformat": 4,
   "nbformat_minor": 5

--- a/docs/operation/bringup_shutdown.rst
+++ b/docs/operation/bringup_shutdown.rst
@@ -16,7 +16,7 @@ To bring up an ALOHA robot configuration (Mobile, Solo, or Stationary), you need
 .. important::
 
   The robot argument is required to specify which ALOHA configuration to bring up.
-  Choose the value that matches your setup, such as ``aloha_static``, ``aloha_solo``, or ``aloha_mobile``.
+  Choose the value that matches your setup, such as ``aloha_stationary``, ``aloha_solo``, or ``aloha_mobile``.
 
 .. warning::
 
@@ -45,7 +45,7 @@ While the ALOHA bringup is running in another terminal, open a new one and run t
 .. important::
 
   The robot argument is required to specify which ALOHA configuration to bring up.
-  Choose the value that matches your setup, such as ``aloha_static``, ``aloha_solo``, or ``aloha_mobile``.
+  Choose the value that matches your setup, such as ``aloha_stationary``, ``aloha_solo``, or ``aloha_mobile``.
 
 The follower arms will move to their "staged" configurations and then place themselves into their sleep configurations.
 

--- a/docs/training/hugging_face.rst
+++ b/docs/training/hugging_face.rst
@@ -71,7 +71,7 @@ You can use the following Python script to upload your dataset:
 
     api.upload_folder(
         folder_path="~/aloha_data/aloha_stationary_block_pickup",
-        repo_id="TrossenRoboticsCommunity/aloha_static_datasets",
+        repo_id="TrossenRoboticsCommunity/aloha_stationary_datasets",
         repo_type="dataset",
     )
 

--- a/docs/training/lerobot_guide.rst
+++ b/docs/training/lerobot_guide.rst
@@ -170,7 +170,7 @@ To visualize a single dataset episode from the Hugging Face Hub:
 .. code-block:: bash
 
    $ python lerobot/scripts/visualize_dataset.py \
-      --repo-id ${HF_USER}/aloha_static_block_pickup \
+      --repo-id ${HF_USER}/aloha_stationary_block_pickup \
       --episode-index 0
 
 To visualize a single dataset episode stored locally:
@@ -178,7 +178,7 @@ To visualize a single dataset episode stored locally:
 .. code-block:: bash
 
    $ DATA_DIR='./my_local_data_dir' python lerobot/scripts/visualize_dataset.py \
-      --repo-id TrossenRoboticsCommunity/aloha_static_block_pickup \
+      --repo-id TrossenRoboticsCommunity/aloha_stationary_block_pickup \
       --episode-index 0
 
 Replay Recorded Episodes


### PR DESCRIPTION
This PR fixes the name of the bimanual robot from `aloha_static` to `aloha_stationary` to match the actual configurations in the aloha repository.